### PR TITLE
Added Arcade Folder Directories

### DIFF
--- a/custom-metalslug.cfg
+++ b/custom-metalslug.cfg
@@ -5,3 +5,9 @@
 /home/pi/RetroPie/roms/neogeo/mslug3.zip
 /home/pi/RetroPie/roms/neogeo/mslug4.zip
 /home/pi/RetroPie/roms/neogeo/mslug5.zip
+/home/pi/RetroPie/roms/arcade/mslugx.zip
+/home/pi/RetroPie/roms/arcade/mslug.zip
+/home/pi/RetroPie/roms/arcade/mslug2.zip
+/home/pi/RetroPie/roms/arcade/mslug3.zip
+/home/pi/RetroPie/roms/arcade/mslug4.zip
+/home/pi/RetroPie/roms/arcade/mslug5.zip


### PR DESCRIPTION
Since Retropie allows for putting all MAME, NEOGEO, and FBA roms into one ARCADE folder, I have added the /home/pi/RetroPie/roms/arcade directory for each of these Metal Slug zip files.